### PR TITLE
ENH Get storybook to work with CMS 5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,10 +19,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '10'
+          node-version: '18'
       - uses: nanasess/setup-php@master
         with:
-          php-version: '7.4'
+          php-version: '8.1'
 
       - name: Get Composer
         run: bash get_composer.bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 storybook-static
 composer*
+silverstripe-admin/

--- a/build_pattern_lib.bash
+++ b/build_pattern_lib.bash
@@ -8,9 +8,13 @@ trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 git clone https://github.com/silverstripe/silverstripe-admin.git
 cd silverstripe-admin
-export COMPOSER_ROOT_VERSION=1.x-dev
-../composer.phar require silverstripe/asset-admin:1.x-dev --prefer-source
-../composer.phar require dnadesign/silverstripe-elemental:4.x-dev --prefer-source
+git checkout 2
+export COMPOSER_ROOT_VERSION=2.x-dev
+composer config allow-plugins.composer/installers true
+composer config allow-plugins.silverstripe/recipe-plugin true
+composer config allow-plugins.silverstripe/vendor-plugin true
+../composer.phar require silverstripe/asset-admin:2.x-dev --prefer-source --no-install
+../composer.phar require dnadesign/silverstripe-elemental:5.x-dev --prefer-source
 yarn cache clean
 yarn install
 yarn static-pattern-lib


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-cms/issues/2842

This PR hasn't triggered a CI run because CI is setup to only run on the `master` branch - https://github.com/silverstripe/silverstripe-pattern-lib/blob/master/.github/workflows/main.yml#L5 - we also cannot change this without merging to master

Given this is very low risk I think we should just merge as is to see thing work as they should, and then make further changes if required.